### PR TITLE
math: only link to libm on unixes

### DIFF
--- a/crates/math/lib.rs
+++ b/crates/math/lib.rs
@@ -17,7 +17,7 @@ macro_rules! define {
         $(
             #[inline(always)]
             pub fn $name($($a: $t),*) $(-> $r)? {
-                #[link(name = "m")]
+                #[cfg_attr(unix, link(name = "m"))]
                 extern "C" {
                     fn $name($($a: $t),*) $(-> $r)?;
                 }


### PR DESCRIPTION
Fixes unexpected libm link attempt on Windows